### PR TITLE
[Bugfix/#130] 팟 이동 오류 수정

### DIFF
--- a/src/apis/types/feed.ts
+++ b/src/apis/types/feed.ts
@@ -8,6 +8,7 @@ export interface FeedResponse {
 interface Feeds {
   feedId: number;
   writer: string;
+  writerId: number;
   writerRole: Role;
   title: string;
   content: string;

--- a/src/components/cards/FinishedPotCard/FinishedPotCard.tsx
+++ b/src/components/cards/FinishedPotCard/FinishedPotCard.tsx
@@ -1,15 +1,15 @@
 import { MemberGroup, PotButton } from "@components/index";
 import {
-    container,
-    elementContainer,
-    elementContentStyle,
-    elementTitleStyle,
-    gridContainer,
-    profileContainer,
-    teamElementContainer,
-    titleContainer,
-    titleProfileContainer,
-    titleStyle,
+  container,
+  elementContainer,
+  elementContentStyle,
+  elementTitleStyle,
+  gridContainer,
+  profileContainer,
+  teamElementContainer,
+  titleContainer,
+  titleProfileContainer,
+  titleStyle,
 } from "./FinishedPotCard.style";
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
@@ -18,104 +18,103 @@ import { Role } from "types/role";
 import routes from "@constants/routes";
 
 interface FinishedPotCardProps {
-    id: number;
-    title: string;
-    myRole: string;
-    startDate: string;
-    endDate: string;
-    stacks: string;
-    languages: string;
-    members: Role[];
-    isMyPage: boolean;
-    buttonType?: "edit" | "appeal";
+  id: number;
+  title: string;
+  myRole: string;
+  startDate: string;
+  endDate: string;
+  stacks: string;
+  languages: string;
+  members: Role[];
+  isMyPage: boolean;
+  buttonType?: "edit" | "appeal";
 }
 
 const FinishedPotCard: React.FC<FinishedPotCardProps> = ({
-    id,
-    title,
-    myRole,
-    startDate,
-    endDate,
-    stacks,
-    languages,
-    members,
-    isMyPage,
-    buttonType,
+  id,
+  title,
+  myRole,
+  startDate,
+  endDate,
+  stacks,
+  languages,
+  members,
+  isMyPage,
+  buttonType,
 }: FinishedPotCardProps) => {
-    const navigate = useNavigate();
+  const navigate = useNavigate();
 
-    const [appealModal, setAppealModal] = useState<number | null>(null);
-    const [summaryModal, setSummaryModal] = useState<number | null>(null);
+  const [appealModal, setAppealModal] = useState<number | null>(null);
+  const [summaryModal, setSummaryModal] = useState<number | null>(null);
 
-    const elementList: { title: string; content: string }[] = [
-        { title: "나의 역할", content: myRole },
-        { title: "시작 날짜", content: startDate },
-        { title: "사용 언어", content: languages },
-        { title: "종료 날짜", content: endDate },
-        { title: "팀 구성", content: stacks },
-    ];
+  const elementList: { title: string; content: string }[] = [
+    { title: "나의 역할", content: myRole },
+    { title: "시작 날짜", content: startDate },
+    { title: "사용 언어", content: languages },
+    { title: "종료 날짜", content: endDate },
+    { title: "팀 구성", content: stacks },
+  ];
 
-    const handleClickPot = (id: number) => {
-        if (isMyPage) {
-            setSummaryModal(id);
-        } else {
-            navigate(`${routes.potDetail}/${id}`);
-        }
+  const handleClickPot = (id: number) => {
+    if (isMyPage) {
+      setSummaryModal(id);
+    } else {
+      navigate(`${routes.pot.base}/${id}`);
     }
-    const handleEditPot = (id: number) => {
-        if (buttonType === "edit") {
-            navigate(`${routes.editFinishedPot}/${id}`);
-        } else {
-            setAppealModal(id)
-        }
-    };
+  };
+  const handleEditPot = (id: number) => {
+    if (buttonType === "edit") {
+      navigate(`${routes.editFinishedPot}/${id}`);
+    } else {
+      setAppealModal(id);
+    }
+  };
 
-
-    return (
-        <>
-            <div css={container} onClick={() => handleClickPot(id)}>
-                <div css={titleProfileContainer}>
-                    <div css={titleContainer}>
-                        <h1 css={titleStyle}>{title}</h1>
-                        {isMyPage && (
-                            <PotButton onClick={() => handleEditPot(id)}>
-                                {buttonType === "edit" ? "팟 소개 수정" : "여기서 저는요"}
-                            </PotButton>
-                        )}
-                    </div>
-                    <div css={profileContainer}>
-                        <MemberGroup memberRoleList={members} />
-                    </div>
-                </div>
-                <div css={gridContainer}>
-                    {elementList.map((element) => (
-                        <div
-                            css={
-                                element.title !== "팀 구성"
-                                    ? elementContainer
-                                    : teamElementContainer
-                            }
-                            key={element.title}
-                        >
-                            <p css={elementTitleStyle}>{element.title}</p>
-                            <p css={elementContentStyle}>{element.content}</p>
-                        </div>
-                    ))}
-                </div>
+  return (
+    <>
+      <div css={container} onClick={() => handleClickPot(id)}>
+        <div css={titleProfileContainer}>
+          <div css={titleContainer}>
+            <h1 css={titleStyle}>{title}</h1>
+            {isMyPage && (
+              <PotButton onClick={() => handleEditPot(id)}>
+                {buttonType === "edit" ? "팟 소개 수정" : "여기서 저는요"}
+              </PotButton>
+            )}
+          </div>
+          <div css={profileContainer}>
+            <MemberGroup memberRoleList={members} />
+          </div>
+        </div>
+        <div css={gridContainer}>
+          {elementList.map((element) => (
+            <div
+              css={
+                element.title !== "팀 구성"
+                  ? elementContainer
+                  : teamElementContainer
+              }
+              key={element.title}
+            >
+              <p css={elementTitleStyle}>{element.title}</p>
+              <p css={elementContentStyle}>{element.content}</p>
             </div>
-            {appealModal !== null && (
-                <AppealModal
-                    potId={appealModal}
-                    onCancel={() => setAppealModal(null)}
-                />
-            )}
-            {summaryModal !== null && (
-                <PotSummaryModal
-                    potId={summaryModal}
-                    onCancel={() => setSummaryModal(null)}
-                />
-            )}
-        </>
-    );
+          ))}
+        </div>
+      </div>
+      {appealModal !== null && (
+        <AppealModal
+          potId={appealModal}
+          onCancel={() => setAppealModal(null)}
+        />
+      )}
+      {summaryModal !== null && (
+        <PotSummaryModal
+          potId={summaryModal}
+          onCancel={() => setSummaryModal(null)}
+        />
+      )}
+    </>
+  );
 };
 export default FinishedPotCard;

--- a/src/components/cards/PostCard/PostCard.style.ts
+++ b/src/components/cards/PostCard/PostCard.style.ts
@@ -1,88 +1,93 @@
-import { css } from "@emotion/react"
-import theme from "@styles/theme"
+import { css } from "@emotion/react";
+import theme from "@styles/theme";
 
 export const cardStyle = css`
-    width: 90.8rem;
-    padding: 2.4rem 3rem;
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-    border-radius: 24px;
-    background-color: white;
-    box-shadow:  0px 4px 12px 0px rgba(13, 10, 44, 0.06);
-    border: 1px solid ${theme.color.object.alternative};
-    cursor: pointer;
-`
+  width: 90.8rem;
+  padding: 2.4rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  border-radius: 24px;
+  background-color: white;
+  box-shadow: 0px 4px 12px 0px rgba(13, 10, 44, 0.06);
+  border: 1px solid ${theme.color.object.alternative};
+  cursor: pointer;
+`;
 export const headerContainer = css`
-    display: flex;
-    justify-content: space-between;
-`
+  display: flex;
+  justify-content: space-between;
+`;
 export const profileContainer = css`
-    display: flex;
-    align-items: center;
-    gap: 1.6rem;
-`
+  display: flex;
+  align-items: center;
+  gap: 1.6rem;
+`;
 export const profileImageStyle = css`
-    width: 5rem;
-    height: 5rem;
-    border: 1px solid ${theme.color.object.alternative};
-    border-radius: 50%;
-`
+  width: 5rem;
+  height: 5rem;
+  border: 1px solid ${theme.color.object.alternative};
+  border-radius: 50%;
+`;
 export const nicknameDateContainer = css`
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-`
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+`;
 export const nicknameStyle = css`
-    ${theme.font.bodyBold1}
-    color:${theme.color.object.assistive};
-`
+  ${theme.font.bodyBold1}
+  color:${theme.color.object.assistive};
+  &:hover {
+    text-decoration: underline;
+  }
+`;
 
 export const moreIconStyle = css`
-    width: 2.4rem;
-    height: 2.4rem;
-    margin-bottom: auto;
-    margin-left: auto;
-`
+  width: 2.4rem;
+  height: 2.4rem;
+  margin-bottom: auto;
+  margin-left: auto;
+`;
 
 export const dateStyle = css`
-    color: ${theme.color.interactive.inactive};
-    ${theme.font.caption2}
-`
+  color: ${theme.color.interactive.inactive};
+  ${theme.font.caption2}
+`;
 
 export const titleStyle = css`
-    color: ${theme.color.base.darkgray};
-    ${theme.font.title1}
-`
+  color: ${theme.color.base.darkgray};
+  ${theme.font.title1}
+`;
 export const contentStyle = css`
-    height: 6rem;
-    ${theme.font.caption3}
-    color: ${theme.color.object.assistive};
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-`
+  height: 6rem;
+  ${theme.font.caption3}
+  color: ${theme.color.object.assistive};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+`;
 export const likeContainer = css`
-    display: flex;
-    margin-left: auto;
-    padding: 0.2rem 0;
-    align-items: center;
-    gap: 0.8rem;
-    cursor: pointer;
-`
+  display: flex;
+  margin-left: auto;
+  padding: 0.2rem 0;
+  align-items: center;
+  gap: 0.8rem;
+  cursor: pointer;
+`;
 export const likeTextStyle = css`
-    ${theme.font.label3}
-    color: ${theme.color.interactive.inactive};
-`
+  ${theme.font.label3}
+  color: ${theme.color.interactive.inactive};
+`;
 export const likeIconStyle = (isLike: boolean) => css`
-    width: 2.2rem;
-    height: 2.2rem;
-    fill: ${isLike ? theme.color.feedback.negative : theme.color.interactive.inactive};
-`
+  width: 2.2rem;
+  height: 2.2rem;
+  fill: ${isLike
+    ? theme.color.feedback.negative
+    : theme.color.interactive.inactive};
+`;
 export const likeIconfilledStyle = css`
-    width: 2.2rem;
-    height: 2.2rem;
-    fill: ${theme.color.feedback.negative};
-`
+  width: 2.2rem;
+  height: 2.2rem;
+  fill: ${theme.color.feedback.negative};
+`;

--- a/src/components/cards/PostCard/PostCard.tsx
+++ b/src/components/cards/PostCard/PostCard.tsx
@@ -31,6 +31,7 @@ interface PostCardProps {
   isLiked: boolean;
   profileImage?: string;
   feedId: number;
+  writerId: number;
 }
 
 const PostCard: React.FC<PostCardProps> = ({
@@ -42,6 +43,7 @@ const PostCard: React.FC<PostCardProps> = ({
   likeCount,
   isLiked,
   feedId,
+  writerId,
 }: PostCardProps) => {
   const navigate = useNavigate();
 
@@ -66,15 +68,35 @@ const PostCard: React.FC<PostCardProps> = ({
     window.scrollTo(0, 0);
   };
 
+  const handleUserClick = (writerId: number) => {
+    navigate(`${routes.myPage}/${writerId}`);
+  };
+
   const profileImage = roleImages[role];
 
   return (
     <div css={cardStyle} onClick={() => handleFeedClick(feedId)}>
       <div css={headerContainer}>
         <div css={profileContainer}>
-          <img css={profileImageStyle} src={profileImage} alt="profile" />
+          <img
+            onClick={(e) => {
+              e.stopPropagation();
+              handleUserClick(writerId);
+            }}
+            css={profileImageStyle}
+            src={profileImage}
+            alt="profile"
+          />
           <div css={nicknameDateContainer}>
-            <p css={nicknameStyle}>{nickname}</p>
+            <p
+              onClick={(e) => {
+                e.stopPropagation();
+                handleUserClick(writerId);
+              }}
+              css={nicknameStyle}
+            >
+              {nickname}
+            </p>
             <p css={dateStyle}>{createdAt}</p>
           </div>
         </div>

--- a/src/components/cards/PostCard/PostCard.tsx
+++ b/src/components/cards/PostCard/PostCard.tsx
@@ -18,6 +18,8 @@ import { LikeIcon } from "@assets/svgs";
 import MyFeedDropdown from "@components/commons/Dropdown/MyFeedDropdown/MyFeedDropdown";
 import { roleImages } from "@constants/roleImage";
 import { Role } from "types/role";
+import { useNavigate } from "react-router-dom";
+import routes from "@constants/routes";
 
 interface PostCardProps {
   role: Role;
@@ -28,7 +30,7 @@ interface PostCardProps {
   likeCount: number;
   isLiked: boolean;
   profileImage?: string;
-  onClick: () => void;
+  feedId: number;
 }
 
 const PostCard: React.FC<PostCardProps> = ({
@@ -39,8 +41,10 @@ const PostCard: React.FC<PostCardProps> = ({
   content,
   likeCount,
   isLiked,
-  onClick,
+  feedId,
 }: PostCardProps) => {
+  const navigate = useNavigate();
+
   const [isLike, setIsLike] = useState<boolean>(isLiked);
   const [likes, setLikes] = useState<number>(likeCount);
   const [isMyPost, setIsMyPost] = useState<boolean>(true);
@@ -57,10 +61,15 @@ const PostCard: React.FC<PostCardProps> = ({
     // todo: 삭제하기 api
   };
 
+  const handleFeedClick = (feedId: number) => {
+    navigate(`${routes.feed}/${feedId}`);
+    window.scrollTo(0, 0);
+  };
+
   const profileImage = roleImages[role];
 
   return (
-    <div css={cardStyle} onClick={onClick}>
+    <div css={cardStyle} onClick={() => handleFeedClick(feedId)}>
       <div css={headerContainer}>
         <div css={profileContainer}>
           <img css={profileImageStyle} src={profileImage} alt="profile" />

--- a/src/components/cards/PotCard/PotCard.style.ts
+++ b/src/components/cards/PotCard/PotCard.style.ts
@@ -37,6 +37,9 @@ export const nicknameStyle = css`
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  &:hover {
+    text-decoration: underline;
+  }
 `;
 export const titleStyle = css`
   ${theme.font.bodyBold1};
@@ -54,9 +57,9 @@ export const contentStyle = css`
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 `;
-export const contentContainer =css`
+export const contentContainer = css`
   height: 6rem;
-`
+`;
 export const categoriesContainer = css`
   display: flex;
   gap: 1rem;

--- a/src/components/cards/PotCard/PotCard.tsx
+++ b/src/components/cards/PotCard/PotCard.tsx
@@ -16,7 +16,8 @@ import { roleImages } from "@constants/roleImage";
 import { Role } from "types/role";
 
 interface PotCardProps {
-  id: number;
+  userId: number;
+  potId: number;
   role: Role;
   nickname: string;
   dday: string;
@@ -26,7 +27,8 @@ interface PotCardProps {
 }
 
 const PotCard: React.FC<PotCardProps> = ({
-  id,
+  userId,
+  potId,
   role,
   nickname,
   dday,
@@ -35,14 +37,15 @@ const PotCard: React.FC<PotCardProps> = ({
   categories,
 }: PotCardProps) => {
   const navigate = useNavigate();
-  const handleClickCard = () => {
-    navigate(`/pot/${id}`);
+
+  const handleCardClick = () => {
+    navigate(`/pot/${potId}`);
   };
 
   const profileImage = roleImages[role];
 
   return (
-    <div css={cardStyle} onClick={handleClickCard}>
+    <div css={cardStyle} onClick={handleCardClick}>
       <div css={titleContainer}>
         <img css={profileImageStyle} src={profileImage} alt="profile" />
         <div css={nicknameDdayContainer}>
@@ -55,11 +58,13 @@ const PotCard: React.FC<PotCardProps> = ({
         <p css={contentStyle}>{content}</p>
       </div>
       <div css={categoriesContainer}>
-        {categories.length === 4 ?
-          <Badge content="전체" /> :
+        {categories.length === 4 ? (
+          <Badge content="전체" />
+        ) : (
           categories.map((category, index) => (
             <Badge key={index} content={category} />
-          ))}
+          ))
+        )}
       </div>
     </div>
   );

--- a/src/components/cards/PotCard/PotCard.tsx
+++ b/src/components/cards/PotCard/PotCard.tsx
@@ -14,6 +14,7 @@ import DdayBadge from "@components/commons/Badge/DdayBadge/DdayBadge";
 import { useNavigate } from "react-router-dom";
 import { roleImages } from "@constants/roleImage";
 import { Role } from "types/role";
+import routes from "@constants/routes";
 
 interface PotCardProps {
   userId: number;
@@ -39,7 +40,11 @@ const PotCard: React.FC<PotCardProps> = ({
   const navigate = useNavigate();
 
   const handleCardClick = () => {
-    navigate(`/pot/${potId}`);
+    navigate(`${routes.pot.base}/${potId}`);
+  };
+
+  const handleUserClick = () => {
+    navigate(`${routes.myPage}/${userId}`);
   };
 
   const profileImage = roleImages[role];
@@ -47,9 +52,25 @@ const PotCard: React.FC<PotCardProps> = ({
   return (
     <div css={cardStyle} onClick={handleCardClick}>
       <div css={titleContainer}>
-        <img css={profileImageStyle} src={profileImage} alt="profile" />
+        <img
+          css={profileImageStyle}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleUserClick();
+          }}
+          src={profileImage}
+          alt="profile"
+        />
         <div css={nicknameDdayContainer}>
-          <p css={nicknameStyle}>{nickname}</p>
+          <p
+            onClick={(e) => {
+              e.stopPropagation();
+              handleUserClick();
+            }}
+            css={nicknameStyle}
+          >
+            {nickname}
+          </p>
           <DdayBadge days={dday} />
         </div>
       </div>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -20,7 +20,6 @@ const routes = {
   search: "/search",
   searchResult: "/search-result",
   signUp: "/sign-up",
-  potDetail: "/pot",
   callback: "/callback",
   editPost: "/edit-post/:postId",
   editFinishedPot: "/finished-pot/edit",

--- a/src/pages/EditPot/EditPot.tsx
+++ b/src/pages/EditPot/EditPot.tsx
@@ -23,7 +23,7 @@ const EditPot = () => {
             potId: potIdNumber,
             body: data
         }, {
-            onSuccess: () => navigate(`${routes.potDetail}/${potId}`)
+            onSuccess: () => navigate(`${routes.pot.base}/${potId}`)
         })
     }
     const handleDeletePot = () => {

--- a/src/pages/Home/components/Feed/Feed.tsx
+++ b/src/pages/Home/components/Feed/Feed.tsx
@@ -98,6 +98,7 @@ const Feed = () => {
                     <div key={item.feedId} ref={isLastItem ? ref : null}>
                       <PostCard
                         role={item.writerRole}
+                        writerId={item.writerId}
                         nickname={item.writer}
                         createdAt={item.createdAt}
                         title={item.title}

--- a/src/pages/Home/components/Feed/Feed.tsx
+++ b/src/pages/Home/components/Feed/Feed.tsx
@@ -15,12 +15,8 @@ import { useInView } from "react-intersection-observer";
 import { LoadingSpinnerIcon } from "@assets/svgs";
 import Skeleton from "react-loading-skeleton";
 import "react-loading-skeleton/dist/skeleton.css";
-import { useNavigate } from "react-router-dom";
-import routes from "@constants/routes";
 
 const Feed = () => {
-  const navigate = useNavigate();
-
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [category, setCategory] = useState<string | null>(null);
   const [sort, setSort] = useState<string>("new");
@@ -60,11 +56,6 @@ const Feed = () => {
       fetchNextPage();
     }
   }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
-
-  const handleCardClick = (feedId: number) => {
-    navigate(`${routes.feed}/${feedId}`);
-    window.scrollTo(0, 0);
-  };
 
   return (
     <>
@@ -113,7 +104,7 @@ const Feed = () => {
                         content={item.content}
                         likeCount={item.likeCount}
                         isLiked={item.isLiked}
-                        onClick={() => handleCardClick(item.feedId)}
+                        feedId={item.feedId}
                       />
                     </div>
                   );

--- a/src/pages/Home/components/PopularPots/PopularPots.tsx
+++ b/src/pages/Home/components/PopularPots/PopularPots.tsx
@@ -63,7 +63,8 @@ const PopularPots = () => {
               : data?.pots.map((pot) => (
                   <SwiperSlide key={pot.userId}>
                     <PotCard
-                      id={pot.userId}
+                      userId={pot.userId}
+                      potId={pot.potId}
                       role={pot.userRole}
                       nickname={pot.userNickname}
                       dday={pot.dday}

--- a/src/pages/Pots/AllPot/AllPotPage.tsx
+++ b/src/pages/Pots/AllPot/AllPotPage.tsx
@@ -62,7 +62,8 @@ const AllPotPage: React.FC = () => {
           data.pots.map((pot, index) => (
             <PotCard
               key={index}
-              id={pot.userId}
+              userId={pot.userId}
+              potId={pot.potId}
               role={pot.userRole}
               nickname={pot.userNickname}
               dday={pot.dday}

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -73,7 +73,7 @@ const router = createBrowserRouter([
         element: <SignUpPage />,
       },
       {
-        path: `${routes.potDetail}/:potId`,
+        path: `${routes.pot.base}/:potId`,
         element: <PotDetailPage />,
       },
       {


### PR DESCRIPTION
## 💻 관련 이슈

<!--
ex) close #100
-->

- close #130 

## 💡 작업내용

- 팟 클릭 시 팟 디테일 페이지로 넘어가도록 수정
- 팟/피드 닉네임 호버 시 text-decoration 추가
- 팟/피드 닉네임 및 프로필 클릭 시 유저 프로필로 넘어가도록 구현

## 🧐 참고 사항

- 유저 프로필로 넘어가는 것은 아직 api 미연결로 404 뜹니다.

## 🖼️ 스크린샷 or 실행영상
<!-- 원활한 코드 리뷰를 위해 꼭 올려주세요 -->

https://github.com/user-attachments/assets/f3bb05ea-4b0a-4689-826e-5b75c58af844


## ️✅ 체크리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았나요?
