### PR TITLE
[Refactor/ #183] 다른 사람 페이지 피드 수정 불가능

### DIFF
--- a/src/apis/feedAPI.ts
+++ b/src/apis/feedAPI.ts
@@ -1,5 +1,11 @@
 import { useParams } from "react-router-dom";
-import { apiGet, authApiGet, authApiPost, authApiPatch } from "./apiUtils";
+import {
+  apiGet,
+  authApiGet,
+  authApiPost,
+  authApiPatch,
+  authApiDelete,
+} from "./apiUtils";
 import {
   FeedPatch,
   FeedResponse,
@@ -37,4 +43,8 @@ export const getFeedDetails = async (feedId: number) => {
 
 export const postFeedLike = async (feedId: number) => {
   return authApiPost<Record<string, string>>(`/feeds/${feedId}/like`);
+};
+
+export const DeleteFeed = async (feedId: number) => {
+  return authApiDelete(`/feeds/${feedId}`);
 };

--- a/src/apis/hooks/feeds/useDeleteFeed.ts
+++ b/src/apis/hooks/feeds/useDeleteFeed.ts
@@ -1,0 +1,9 @@
+import { useMutation } from "@tanstack/react-query";
+import { DeleteFeed } from "apis/feedAPI";
+
+const useDeleteFeed = () => {
+  return useMutation({
+    mutationFn: (feedId: number) => DeleteFeed(feedId),
+  });
+};
+export default useDeleteFeed;

--- a/src/apis/hooks/users/usePatchFinishedPot.ts
+++ b/src/apis/hooks/users/usePatchFinishedPot.ts
@@ -14,7 +14,7 @@ const usePatchFinishedPot = () => {
       patchFinishedPot(potId, body),
 
     onSuccess: () => {
-      navigate(`${routes.pot.base}`);
+      navigate(`${routes.pot.madeByMe}`);
       showSnackbar({
         message: "작성한 내용이 저장되었습니다.",
         severity: "success",

--- a/src/components/cards/PostCard/PostCard.tsx
+++ b/src/components/cards/PostCard/PostCard.tsx
@@ -21,6 +21,9 @@ import { Role } from "types/role";
 import { useNavigate } from "react-router-dom";
 import routes from "@constants/routes";
 import usePostFeedLike from "apis/hooks/feeds/usePostFeedLike";
+import { DeleteFeed } from "apis/feedAPI";
+import useDeleteFeed from "apis/hooks/feeds/useDeleteFeed";
+import useGetMyPage from "apis/hooks/users/useGetMyPage";
 
 interface PostCardProps {
   role: Role;
@@ -50,10 +53,14 @@ const PostCard: React.FC<PostCardProps> = ({
 }: PostCardProps) => {
   const { mutate: likeFeed } = usePostFeedLike();
 
+  const { refetch } = useGetMyPage({ dataType: "feed" });
+
   const navigate = useNavigate();
 
   const [isLike, setIsLike] = useState<boolean>(isLiked);
   const [likes, setLikes] = useState<number>(likeCount);
+
+  const { mutate: deleteFeed } = useDeleteFeed();
 
   const accessToken = localStorage.getItem("accessToken");
 
@@ -74,7 +81,14 @@ const PostCard: React.FC<PostCardProps> = ({
   };
 
   const handleDelete = () => {
-    // todo: 삭제하기 api
+    if (feedId) {
+      deleteFeed(feedId, {
+        onSuccess: () => {
+          refetch();
+          window.scrollTo(0, 0);
+        },
+      });
+    }
   };
 
   const handleFeedClick = (feedId: number) => {

--- a/src/components/cards/PostCard/PostCard.tsx
+++ b/src/components/cards/PostCard/PostCard.tsx
@@ -33,6 +33,7 @@ interface PostCardProps {
   profileImage?: string;
   feedId: number;
   writerId: number;
+  isMyPost: boolean;
 }
 
 const PostCard: React.FC<PostCardProps> = ({
@@ -45,6 +46,7 @@ const PostCard: React.FC<PostCardProps> = ({
   isLiked,
   feedId,
   writerId,
+  isMyPost,
 }: PostCardProps) => {
   const { mutate: likeFeed } = usePostFeedLike();
 
@@ -52,7 +54,6 @@ const PostCard: React.FC<PostCardProps> = ({
 
   const [isLike, setIsLike] = useState<boolean>(isLiked);
   const [likes, setLikes] = useState<number>(likeCount);
-  const [isMyPost, setIsMyPost] = useState<boolean>(true);
 
   const accessToken = localStorage.getItem("accessToken");
 

--- a/src/pages/EditPost/EditPost.tsx
+++ b/src/pages/EditPost/EditPost.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useForm, FormProvider, SubmitHandler } from "react-hook-form";
 import {
   buttonContainer,
@@ -14,14 +14,18 @@ import { Button, PotButton, UploadToast, PostForm } from "@components/index";
 import { FeedPatch } from "apis/types/feed";
 import usePatchFeed from "apis/hooks/feeds/usePatchFeed";
 import useGetFeedDetails from "apis/hooks/feeds/useGetFeedDetails";
+import useDeleteFeed from "apis/hooks/feeds/useDeleteFeed";
+import routes from "@constants/routes";
 
 const EditPost = () => {
   const { feedId } = useParams();
 
   const feedIdNumber = feedId ? ~~feedId : 0;
+  const navigate = useNavigate();
 
   const { data } = useGetFeedDetails({ feedId: feedIdNumber });
   const { mutate: editFeed } = usePatchFeed();
+  const { mutate: deleteFeed } = useDeleteFeed();
 
   const [showToast, setShowToast] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -61,6 +65,16 @@ const EditPost = () => {
     }
   };
 
+  const handleDelete = () => {
+    if (feedIdNumber) {
+      deleteFeed(feedIdNumber, {
+        onSuccess: () => {
+          navigate(`${routes.home}`);
+        },
+      });
+    }
+  };
+
   return (
     <main>
       {showToast && (
@@ -75,7 +89,7 @@ const EditPost = () => {
               게시물 수정하기
               <PotIcon css={iconStyle} />
               <div css={buttonContainer}>
-                <PotButton onClick={() => setShowDeleteModal(true)} type="red">
+                <PotButton onClick={handleDelete} type="red">
                   삭제하기
                 </PotButton>
                 <Button variant="action" type="submit" disabled={!isValid}>

--- a/src/pages/FeedDetail/FeedDetail.style.ts
+++ b/src/pages/FeedDetail/FeedDetail.style.ts
@@ -14,6 +14,13 @@ export const headerContainer = css`
 export const titleContainer = css`
   display: flex;
   gap: 1rem;
+  justify-content: space-between;
+`;
+
+export const titleWrapper = css`
+  display: flex;
+  gap: 1rem;
+  align-items: center;
 `;
 
 export const iconStyle = css`

--- a/src/pages/FeedDetail/FeedDetail.tsx
+++ b/src/pages/FeedDetail/FeedDetail.tsx
@@ -12,11 +12,13 @@ import {
   profileStyle,
   titleContainer,
   titleStyle,
+  titleWrapper,
 } from "./FeedDetail.style";
 import useGetFeedDetail from "apis/hooks/feeds/useGetFeedDetail";
 import { useNavigate, useParams } from "react-router-dom";
 import { roleImages } from "@constants/roleImage";
 import routes from "@constants/routes";
+import { PotButton } from "@components/index";
 
 const FeedDetail = () => {
   const { feedId } = useParams();
@@ -38,12 +40,19 @@ const FeedDetail = () => {
     navigate(`${routes.userProfile}/${userId}`);
   };
 
+  const handleEdit = () => {
+    navigate(`${routes.feed.edit}/${feedId}`);
+  };
+
   return (
     <main css={mainContainer}>
       <div css={headerContainer}>
         <div css={titleContainer}>
-          <LeftIcon type="button" onClick={handleClick} css={iconStyle} />
-          <h1 css={titleStyle}>{data?.title}</h1>
+          <div css={titleWrapper}>
+            <LeftIcon type="button" onClick={handleClick} css={iconStyle} />
+            <h1 css={titleStyle}>{data?.title}</h1>
+          </div>
+          <PotButton onClick={handleEdit}>수정</PotButton>
         </div>
         <div css={profileContainer}>
           <img

--- a/src/pages/FeedDetail/FeedDetail.tsx
+++ b/src/pages/FeedDetail/FeedDetail.tsx
@@ -19,10 +19,13 @@ import { useNavigate, useParams } from "react-router-dom";
 import { roleImages } from "@constants/roleImage";
 import routes from "@constants/routes";
 import { PotButton } from "@components/index";
+import useGetMyProfile from "apis/hooks/users/useGetMyProfile";
 
 const FeedDetail = () => {
   const { feedId } = useParams();
   const numericFeedId = Number(feedId);
+  const { data: user } = useGetMyProfile();
+
   const { data } = useGetFeedDetail(numericFeedId);
 
   const navigate = useNavigate();
@@ -52,7 +55,9 @@ const FeedDetail = () => {
             <LeftIcon type="button" onClick={handleClick} css={iconStyle} />
             <h1 css={titleStyle}>{data?.title}</h1>
           </div>
-          <PotButton onClick={handleEdit}>수정</PotButton>
+          {user?.id === data?.writerId && (
+            <PotButton onClick={handleEdit}>수정</PotButton>
+          )}{" "}
         </div>
         <div css={profileContainer}>
           <img

--- a/src/pages/Home/components/Feed/Feed.tsx
+++ b/src/pages/Home/components/Feed/Feed.tsx
@@ -106,6 +106,7 @@ const Feed = () => {
                         likeCount={item.likeCount}
                         isLiked={item.isLiked}
                         feedId={item.feedId}
+                        isMyPost={false}
                       />
                     </div>
                   );

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -57,6 +57,7 @@ const MyPage = () => {
                   content={post.content}
                   feedId={post.feedId}
                   writerId={post.writerId}
+                  isMyPost={true}
                 />
               ))
             : data.completedPots.map((pot) => {

--- a/src/pages/SearchResult/SearchResult.tsx
+++ b/src/pages/SearchResult/SearchResult.tsx
@@ -125,6 +125,7 @@ const SearchResult = () => {
               isLiked={feed.isLiked}
               feedId={feed.feedId}
               writerId={feed.userId}
+              isMyPost={false}
             />
           ))}
         </div>

--- a/src/pages/UserPage/UserPage.tsx
+++ b/src/pages/UserPage/UserPage.tsx
@@ -65,6 +65,7 @@ const UserPage = () => {
                   content={post.content}
                   feedId={post.feedId}
                   writerId={post.writerId}
+                  isMyPost={false}
                 />
               ))
             : data.completedPots.map((pot) => (


### PR DESCRIPTION
## 💻 관련 이슈

- close #183 

## 💡 작업내용

- 사람 페이지 피드 수정 불가능, 삭제 API 연동, 피드 수정 버튼 추가, 끓은팟 수정하기 경로 변경
-
## 🧐 참고 사항

-

## 🖼️ 스크린샷 or 실행영상
<!-- 원활한 코드 리뷰를 위해 꼭 올려주세요 -->
  
![image](https://github.com/user-attachments/assets/49890117-337e-4ceb-b35d-441d8a9ed157)


## ️✅ 체크리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았나요?
