### PR TITLE
[Refactor/#245] 실시간 인기 팟 조회 수정

### DIFF
--- a/src/components/cards/PotCard/PotCard.style.ts
+++ b/src/components/cards/PotCard/PotCard.style.ts
@@ -3,7 +3,7 @@ import theme from "@styles/theme";
 
 export const cardStyle = css`
   width: 30rem;
-  height: 22.1rem;
+  height: 21.3rem;
   padding: 2.8rem 1.6rem;
   border-radius: 24px;
   box-shadow: 0px 4px 12px 0px rgba(13, 10, 44, 0.06);

--- a/src/components/layouts/SideBar/SideBar.style.ts
+++ b/src/components/layouts/SideBar/SideBar.style.ts
@@ -10,6 +10,7 @@ export const mainContainer = (top: number) => css`
   left: 2rem;
   transform: translateY(-50%);
   transition: top 0.5s ease-in-out;
+  z-index: 10;
 `;
 
 export const container = css`

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -2,42 +2,41 @@ import { PotIcon, RightIcon } from "@assets/svgs";
 import { Button, CtaCard, FloatingButton } from "@components/index";
 
 import {
-	container,
-	content,
-	contentTitle,
-	iconStyle,
-	bannerStyle,
-	bannerTitleStyle,
-	spanStyle,
-	bannerSubtitleStyle,
-	buttonStyle,
-	buttonIconStyle,
-	bannerContainer,
-} from './Home.style';
+  container,
+  content,
+  contentTitle,
+  iconStyle,
+  bannerStyle,
+  bannerTitleStyle,
+  spanStyle,
+  bannerSubtitleStyle,
+  buttonStyle,
+  buttonIconStyle,
+  bannerContainer,
+} from "./Home.style";
 
-import 'swiper/swiper-bundle.css';
-import 'swiper';
-import { useNavigate } from 'react-router-dom';
-import routes from '@constants/routes';
-import { Feed, PopularPots } from './components';
+import "swiper/swiper-bundle.css";
+import "swiper";
+import { useNavigate } from "react-router-dom";
+import routes from "@constants/routes";
+import { Feed, PopularPots } from "./components";
 
 const Home: React.FC = () => {
-	const navigate = useNavigate();
-	const link = `https://kauth.kakao.com/oauth/authorize?client_id=${import.meta.env.VITE_REST_API_KEY}&redirect_uri=${
-		import.meta.env.VITE_REDIRECT_URI
-	}&response_type=code
+  const navigate = useNavigate();
+  const link = `https://kauth.kakao.com/oauth/authorize?client_id=${
+    import.meta.env.VITE_REST_API_KEY
+  }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&response_type=code
 &scope=account_email
 &prompt=login`;
 
-	const handleClick = () => {
-		const token = localStorage.getItem('accessToken');
-		if (token) {
-			navigate(routes.createPot);
-		} else {
-			window.location.href = link;
-		}
-	};
-
+  const handleClick = () => {
+    const token = localStorage.getItem("accessToken");
+    if (token) {
+      navigate(routes.createPot);
+    } else {
+      window.location.href = link;
+    }
+  };
 
   return (
     <>
@@ -61,7 +60,7 @@ const Home: React.FC = () => {
           <div css={content}>
             <div css={contentTitle}>
               <p>실시간 인기 팟</p>
-              <PotIcon css={iconStyle} />
+              <p>🔥</p>
             </div>
             <PopularPots />
           </div>

--- a/src/pages/Home/components/PopularPots/PopularPots.style.ts
+++ b/src/pages/Home/components/PopularPots/PopularPots.style.ts
@@ -4,7 +4,7 @@ import theme from "@styles/theme";
 export const swiperContainer = css`
   position: relative;
   overflow: hidden;
-  width: 84.8rem;
+  width: 94.8rem;
 
   .swiper-button-next,
   .swiper-button-prev {

--- a/src/pages/Home/components/PopularPots/PopularPots.style.ts
+++ b/src/pages/Home/components/PopularPots/PopularPots.style.ts
@@ -21,15 +21,15 @@ export const buttonContainer = css`
 `;
 
 export const pageNumberStyle = css`
-  ${theme.font.body2}
-  color: ${theme.color.object.assistive};
+  ${theme.font.caption3}
+  color: ${theme.color.point.gray};
 `;
 
 export const buttonStyle = css`
   padding: 1rem;
   border-radius: 50%;
   border: none;
-  background-color: ${theme.color.object.normal};
+  background-color: ${theme.color.point.normal};
   height: 4.4rem;
 `;
 

--- a/src/pages/Home/components/PopularPots/PopularPots.tsx
+++ b/src/pages/Home/components/PopularPots/PopularPots.tsx
@@ -1,88 +1,107 @@
-import { Swiper, SwiperSlide } from 'swiper/react';
-import { Navigation, Pagination } from 'swiper/modules';
-import { buttonContainer, buttonStyle, iconStyle, pageNumberStyle, swiperContainer } from './PopularPots.style';
-import { PotCard } from '@components/index';
-import useGetPots from 'apis/hooks/pots/useGetPots';
-import { useState } from 'react';
-import { LeftIcon } from '@assets/svgs';
-import Skeleton from 'react-loading-skeleton';
-import { cardStyle } from '@components/cards/PotCard/PotCard.style';
-import 'react-loading-skeleton/dist/skeleton.css';
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Navigation, Pagination } from "swiper/modules";
+import {
+  buttonContainer,
+  buttonStyle,
+  iconStyle,
+  pageNumberStyle,
+  swiperContainer,
+} from "./PopularPots.style";
+import { PotCard } from "@components/index";
+import useGetPots from "apis/hooks/pots/useGetPots";
+import { useState } from "react";
+import { LeftIcon } from "@assets/svgs";
+import Skeleton from "react-loading-skeleton";
+import { cardStyle } from "@components/cards/PotCard/PotCard.style";
+import "react-loading-skeleton/dist/skeleton.css";
 
 const PopularPots = () => {
-	const [currentPage, setCurrentPage] = useState(1);
-	const { data, isLoading } = useGetPots({
-		page: currentPage,
-		size: 3,
-		recruitmentRole: null,
-	});
+  const [currentPage, setCurrentPage] = useState(1);
+  const { data, isLoading } = useGetPots({
+    page: 1,
+    size: 9,
+    recruitmentRole: null,
+  });
 
-	const totalPages = 3;
+  const pots = data?.pots ?? [];
+  const totalPages = Math.ceil(pots.length / 3);
+  const currentPots = pots.slice((currentPage - 1) * 3, currentPage * 3);
 
-	const handleNextPage = () => {
-		if (currentPage < totalPages) {
-			setCurrentPage(currentPage + 1);
-		}
-	};
+  const handleNextPage = () => {
+    if (currentPage < totalPages) {
+      setCurrentPage(currentPage + 1);
+    }
+  };
 
-	const handlePrevPage = () => {
-		if (currentPage > 1) {
-			setCurrentPage(currentPage - 1);
-		}
-	};
+  const handlePrevPage = () => {
+    if (currentPage > 1) {
+      setCurrentPage(currentPage - 1);
+    }
+  };
 
-	return (
-		<>
-			{data?.pots?.length == 0 ? (
-				<p>데이터가 없습니다.</p>
-			) : (
-				<>
-					<Swiper
-						css={swiperContainer}
-						key={currentPage}
-						modules={[Pagination, Navigation]}
-						centeredSlides={false}
-						spaceBetween={16}
-						slidesPerView={3}
-						slidesPerGroup={3}
-						observer={true}
-						observeParents={true}>
-						{isLoading
-							? Array.from({ length: 3 }).map((_, index) => (
-									<SwiperSlide key={`skeleton-${index}`}>
-										<Skeleton css={cardStyle} />
-									</SwiperSlide>
-							  ))
-							: data?.pots.map((pot) => (
-									<SwiperSlide key={pot.potId}>
-										<PotCard
-											userId={pot.userId}
-											potId={pot.potId}
-											role={pot.userRole}
-											nickname={pot.userNickname}
-											dday={pot.dday}
-											title={pot.potName}
-											content={pot.potContent}
-											categories={pot.recruitmentRoles}
-										/>
-									</SwiperSlide>
-							  ))}
-						<div css={buttonContainer}>
-							<button type="button" css={buttonStyle} onClick={handlePrevPage} disabled={currentPage === 1}>
-								<LeftIcon />
-							</button>
-							<p css={pageNumberStyle}>
-								{currentPage} / {totalPages}
-							</p>
-							<button type="button" css={buttonStyle} onClick={handleNextPage} disabled={currentPage === totalPages}>
-								<LeftIcon css={iconStyle} />
-							</button>
-						</div>
-					</Swiper>
-				</>
-			)}
-		</>
-	);
+  return (
+    <>
+      {data?.pots?.length == 0 ? (
+        <p>데이터가 없습니다.</p>
+      ) : (
+        <>
+          <Swiper
+            css={swiperContainer}
+            key={currentPage}
+            modules={[Pagination, Navigation]}
+            centeredSlides={false}
+            spaceBetween={16}
+            slidesPerView={3}
+            slidesPerGroup={3}
+            observer={true}
+            observeParents={true}
+          >
+            {isLoading
+              ? Array.from({ length: 3 }).map((_, index) => (
+                  <SwiperSlide key={`skeleton-${index}`}>
+                    <Skeleton css={cardStyle} />
+                  </SwiperSlide>
+                ))
+              : currentPots.map((pot) => (
+                  <SwiperSlide key={pot.potId}>
+                    <PotCard
+                      userId={pot.userId}
+                      potId={pot.potId}
+                      role={pot.userRole}
+                      nickname={pot.userNickname}
+                      dday={pot.dday}
+                      title={pot.potName}
+                      content={pot.potContent}
+                      categories={pot.recruitmentRoles}
+                    />
+                  </SwiperSlide>
+                ))}
+            <div css={buttonContainer}>
+              <button
+                type="button"
+                css={buttonStyle}
+                onClick={handlePrevPage}
+                disabled={currentPage === 1}
+              >
+                <LeftIcon />
+              </button>
+              <p css={pageNumberStyle}>
+                {currentPage} / {totalPages}
+              </p>
+              <button
+                type="button"
+                css={buttonStyle}
+                onClick={handleNextPage}
+                disabled={currentPage === totalPages}
+              >
+                <LeftIcon css={iconStyle} />
+              </button>
+            </div>
+          </Swiper>
+        </>
+      )}
+    </>
+  );
 };
 
 export default PopularPots;

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -25,7 +25,7 @@ export const globalStyles = css`
 
   main {
     min-height: calc(100vh - 58px);
-    width: 908px;
+    width: 1100px;
     margin: 0 auto;
   }
 `;


### PR DESCRIPTION
## 💻 관련 이슈

<!--
ex) close #100
-->

- close #245 

## 💡 작업내용

- 실시간 인기 팟 조회 API 호출 로직 수정
- 관련 UI 수정

## 🧐 참고 사항

-

## 🖼️ 스크린샷 or 실행영상
<!-- 원활한 코드 리뷰를 위해 꼭 올려주세요 -->
<img width="1470" height="830" alt="스크린샷 2025-07-13 오후 5 55 29" src="https://github.com/user-attachments/assets/08fee882-1ed1-46aa-af5f-9acaae93c120" />


## ️✅ 체크리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the "실시간 인기 팟" section to display a fire emoji instead of an SVG icon.

* **Improvements**
  * Changed "Popular Pots" pagination to load all items at once and paginate locally for smoother navigation.
  * Increased the width of the main content area and the popular pots container for a more spacious layout.
  * Adjusted card and button styles for improved visual consistency.
  * Sidebar now appears above other elements for better visibility.
  * Enhanced font styles and colors for pagination indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->