### PR TITLE
[Feature/#250] 업무보드 카드 상세보기 화면 구현

### DIFF
--- a/src/components/commons/Badge/StateBadge/StateBadge.style.ts
+++ b/src/components/commons/Badge/StateBadge/StateBadge.style.ts
@@ -13,14 +13,14 @@ export const taskBadgeStyle = (
   background-color: ${content === "진행 전"
     ? theme.color.accent.redBg
     : content === "진행 중"
-    ? theme.color.accent.yellowBg
-    : theme.color.accent.greenBg};
+      ? theme.color.accent.yellowBg
+      : theme.color.accent.greenBg};
   color: ${content === "진행 전"
     ? theme.color.accent.redFg
     : content === "진행 중"
-    ? theme.color.accent.pinkFg
-    : theme.color.status.positive};
-  ${theme.font.captionBold1};
+      ? theme.color.accent.pinkFg
+      : theme.color.status.positive};
+  ${theme.font.caption3};
   box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.16);
   white-space: nowrap;
   cursor: ${clickable ? "pointer" : "default"};
@@ -34,13 +34,13 @@ export const potBadgeStyle = (type: PotStatus) => css`
   background-color: ${type === "ONGOING"
     ? theme.color.accent.yellowBg
     : type === "COMPLETED"
-    ? theme.color.accent.pinkBg
-    : theme.color.accent.blueBg};
+      ? theme.color.accent.pinkBg
+      : theme.color.accent.blueBg};
   color: ${type === "ONGOING"
     ? theme.color.accent.yellowFg
     : type === "COMPLETED"
-    ? theme.color.accent.pinkFg
-    : theme.color.point.darkblue};
+      ? theme.color.accent.pinkFg
+      : theme.color.point.darkblue};
   ${theme.font.caption1};
   white-space: nowrap;
 `;

--- a/src/pages/MyPotDetail/pages/MyPotStatus/MyPotStatus.style.ts
+++ b/src/pages/MyPotDetail/pages/MyPotStatus/MyPotStatus.style.ts
@@ -86,7 +86,7 @@ export const statusBoardStyle = css`
 `;
 
 export const statusTextStyle = css`
-  ${theme.font.bodyBold2};
+  ${theme.font.title1};
   color: ${theme.color.base.darkgray};
 `;
 

--- a/src/pages/TaskDetail/TaskDetail.style.ts
+++ b/src/pages/TaskDetail/TaskDetail.style.ts
@@ -27,7 +27,7 @@ export const rightContainer = css`
 `;
 
 export const titleStyle = css`
-  ${theme.font.bodyBold3};
+  ${theme.font.display1};
   color: ${theme.color.base.darkgray};
   white-space: normal;
   word-break: break-word; 
@@ -49,17 +49,27 @@ export const profileContainer = css`
   display: flex;
   width: 100%;
   align-items: center;
-  gap: 1.9rem;
+  gap: 1.6rem;
+`;
+
+export const profileInnerContainer = css`
+  display: flex;
+  flex-direction: column;
 `;
 
 export const profileImgStyle = css`
-  width: 4rem;
-  height: 4rem;
+  width: 5rem;
+  height: 5rem;
+`;
+
+export const createdDateStyle = css`
+  ${theme.font.caption2};
+  color: ${theme.color.object.hero};
 `;
 
 export const nicknameStyle = css`
-  ${theme.font.caption2};
-  color: ${theme.color.object.assistive};
+  ${theme.font.caption3};
+  color: ${theme.color.base.black};
 `;
 
 export const dateContainer = css`
@@ -71,7 +81,7 @@ export const dateContainer = css`
 
 export const dateStyle = css`
   ${theme.font.caption3};
-  color: ${theme.color.object.assistive};
+  color: ${theme.color.point.hero};
 `;
 
 export const dividerStyle = css`
@@ -92,8 +102,8 @@ export const contentContainerStyle = css`
 `;
 
 export const contentStyle = css`
-  ${theme.font.title1};
-  color: ${theme.color.base.darkgray};
+  ${theme.font.body3};
+  color: ${theme.color.point.gray};
 `;
 
 export const bottomContainer = css`
@@ -128,8 +138,8 @@ export const contributorInner = css`
 `
 
 export const contributorNicknameStyle = css`
-  ${theme.font.caption1};
-  color: ${theme.color.object.assistive};
+  ${theme.font.caption2};
+  color: ${theme.color.base.darkgray};
 `
 
 export const dropdownWrapperStyle = css`

--- a/src/pages/TaskDetail/TaskDetail.tsx
+++ b/src/pages/TaskDetail/TaskDetail.tsx
@@ -22,10 +22,12 @@ import {
   prevButtonStyle,
   dropdownWrapperStyle,
   profileImageStyle,
-  arrowIconStyle
+  arrowIconStyle,
+  profileInnerContainer,
+  createdDateStyle
 } from "./TaskDetail.style";
 import { container } from "../MyPotDetail/MyPotDetail.style"
-import { DdayBadge, StateBadge, MyFeedDropdown } from "@components/index";
+import { DdayBadge, StateBadge, MyFeedDropdown, Badge } from "@components/index";
 import { CalendarIcon, PotIcon } from "@assets/svgs";
 import { ArrowLeftIcon } from "@mui/x-date-pickers";
 import { headerStyle } from "@pages/MyPotDetail/MyPotDetail.style";
@@ -37,7 +39,7 @@ import { AboutWorkModalWrapper, Loading } from "../MyPotDetail/components/index"
 import { APITaskStatus, TaskStatus } from "types/taskStatus";
 import { Role } from "types/role";
 import { roleImages } from "@constants/roleImage";
-import { displayStatus, WorkModal } from "@constants/categories";
+import { displayStatus, partKoreanNameMap, WorkModal } from "@constants/categories";
 import { usePatchMyPotStatus } from "apis/hooks/myPots/usePatchMyPotStatus";
 import { AnotherTaskStatus } from "../../types/taskStatus";
 import { ChangeStatusModalWrapper } from "./components";
@@ -59,6 +61,7 @@ const TaskDetailPage: React.FC = () => {
     potId: potIdNumber,
     taskId: taskIdNumber,
   });
+  console.log(task);
   const { mutate: deleteTask, isPending: isDeletePending } = useDeleteMyPotTask();
   const { mutate: patchStatus, isPending: isStatusPending } = usePatchMyPotStatus();
 
@@ -150,6 +153,7 @@ const TaskDetailPage: React.FC = () => {
           <button onClick={handlePrev} css={prevButtonStyle}>
             <ArrowLeftIcon css={arrowIconStyle} />
           </button>
+          <DdayBadge days={task.result.dday} />
           <div css={titleStyle}>{task.result.title}</div>
         </div>
         <div css={rightContainer}>
@@ -170,18 +174,22 @@ const TaskDetailPage: React.FC = () => {
           src={roleImages[task.result.creatorRole as Role] ?? ""}
           alt={task.result.creatorNickname}
         />
-        <span css={nicknameStyle}>{task.result.creatorNickname}</span>
-        <DdayBadge days={task.result.dday} />
+        <div css={profileInnerContainer}>
+          <span css={nicknameStyle}>{task.result.creatorNickname}</span>
+          <span css={createdDateStyle}>{'2025년 2월 8일 15:20'}</span>
+          {/* API 에서 건네주는 createdDate가 없어서 임의 작성 */}
+        </div>
       </div>
+      <div css={dividerStyle} />
       <div css={dateContainer}>
         <CalendarIcon />
         <span css={dateStyle}>{task.result.deadLine}</span>
       </div>
-      <div css={dividerStyle} />
       <div css={bottomContainer}>
         <div css={contentContainerStyle}>
           <span css={contentStyle}>{task.result.description}</span>
         </div>
+        <div css={dividerStyle} />
         <header css={headerStyle}>
           <div css={statusTextStyle}>업무 참여자</div>
           <PotIcon css={iconStyle} />
@@ -193,6 +201,7 @@ const TaskDetailPage: React.FC = () => {
             <div css={contributorInner}>
               <img src={roleImages[participant.role as Role]} css={profileImageStyle} alt="프로필" />
               <span css={contributorNicknameStyle}>{participant.nickName}</span>
+              <Badge key={index} content={partKoreanNameMap[participant.role]} />
             </div>
           </div>
         ))}


### PR DESCRIPTION
## 💻 관련 이슈

Feature/#250

- close #

## 💡 작업내용

- 업무 보드의 카드 상세보기 화면 수정

## 🧐 참고 사항

- createdAt 임의 값으로 작성

## 🖼️ 스크린샷 or 실행영상
<img width="1154" height="742" alt="image" src="https://github.com/user-attachments/assets/abbdad0a-f170-4401-8193-0f59a2a3cf0e" />

## ️✅ 체크리스트 (PR 올리기 전 아래 내용을 확인해 주세요)

- [x] Reviewers를 지정해주세요
- [x] Assignees는 본인을 선택해주세요
- [x] label을 선택해주세요
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았나요?
